### PR TITLE
Fix ignoring excluding file when name is nil

### DIFF
--- a/Sources/hackscode/main.swift
+++ b/Sources/hackscode/main.swift
@@ -79,7 +79,7 @@ let sourcesBuildPhase = target
 
 let shouldDelete: (PBXFileReference) -> Bool = { fileReference in
     let nameOrPath = fileReference.name ?? fileReference.path!
-    if let nameOrPath = fileReference.name, keepNames.contains(where: { nameOrPath.contains($0) }) {
+    if keepNames.contains(where: { nameOrPath.contains($0) }) {
         return false
     }
 


### PR DESCRIPTION
Files like this was removed from BuildFile even if it's listed in --excluding option.

```
F24981D91F7B2D6100655E28 /* ExecutorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFile  Type = sourcecode.swift; path = ExecutorSpec.swift; sourceTree = "<group>"; };
```